### PR TITLE
fix height for waybar

### DIFF
--- a/users/beleap/config/sway/waybar/style.css
+++ b/users/beleap/config/sway/waybar/style.css
@@ -130,10 +130,10 @@ window#waybar.hidden {
 #bluetooth,
 #tray,
 #wireplumber {
-	margin-top: 8px;
+	margin-top: 4px;
 	margin-left: 4px;
 	margin-right: 4px;
 	padding-left: 16px;
 	padding-right: 16px;
-	margin-bottom: 8px;
+	margin-bottom: 4px;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Style:**
- Adjusted the margin values for the `#bluetooth`, `#tray`, and `#wireplumber` elements in the user interface. The top and bottom margins have been reduced for a more compact and streamlined look. This change will not affect the functionality but will enhance the visual experience for the end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->