### PR TITLE
fix things

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -154,11 +154,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1698670511,
-        "narHash": "sha256-jQIu3UhBMPHXzVkHQO1O2gg8SVo5lqAVoC6mOaLQcLQ=",
+        "lastModified": 1698795315,
+        "narHash": "sha256-fF5ScAWLMHXOuqsbLSG137kS1D+gr9JPtm4H2c4yBbU=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "8e5416b478e465985eec274bc3a018024435c106",
+        "rev": "9bc7d84b8213255ecd5eb6299afdb77c36ece71d",
         "type": "github"
       },
       "original": {
@@ -177,11 +177,11 @@
       },
       "locked": {
         "dir": "contrib",
-        "lastModified": 1698692817,
-        "narHash": "sha256-MDsFv1QQmNg9qDEQZB3Q/2g/Cru4ryNmmbTj7/DSZLo=",
+        "lastModified": 1698765225,
+        "narHash": "sha256-K30xCGRbmKYj+NY7O0lvsPGctVp6shfQs61BAVq0Plc=",
         "owner": "neovim",
         "repo": "neovim",
-        "rev": "6d1a2f2c3c51560555ea6f7867273635d07eb287",
+        "rev": "746a153bc1a1bc1433a1246fcf454eeb058b9de1",
         "type": "github"
       },
       "original": {
@@ -200,11 +200,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1698710448,
-        "narHash": "sha256-uMyGinUm0OzVQCCl/RjVL1gG/a+yR7ufNo6a9KAhp8g=",
+        "lastModified": 1698796878,
+        "narHash": "sha256-PYJ3JhhiAfGMODUDJ7HAB0BWJuHPZXLb/Zxo1OQDStA=",
         "owner": "nix-community",
         "repo": "neovim-nightly-overlay",
-        "rev": "18b6246179670aa3fd4fe983610e56c419191f0d",
+        "rev": "234cabb19dee74f1c6e7df3d52798c755e313392",
         "type": "github"
       },
       "original": {

--- a/hosts/beleap-thinkpad/configuration.nix
+++ b/hosts/beleap-thinkpad/configuration.nix
@@ -1,5 +1,5 @@
-{ config, pkgs, specialArgs, ... }:
-{
+{ pkgs, specialArgs, ... }:
+rec {
   imports =
     [
       ./hardware-configuration.nix
@@ -7,6 +7,7 @@
         inherit pkgs; 
         overlays = specialArgs.overlays;
         lib = pkgs.lib;
+        hostname = networking.hostName;
       })
     ];
 

--- a/hosts/beleap-xps-9510/configuration.nix
+++ b/hosts/beleap-xps-9510/configuration.nix
@@ -1,6 +1,5 @@
 { config, pkgs, specialArgs, ... }:
-
-{
+rec {
   imports =
     [
       ./hardware-configuration.nix
@@ -8,6 +7,7 @@
         inherit pkgs; 
         overlays = specialArgs.overlays;
         lib = pkgs.lib;
+        hostname = networking.hostName;
       })
     ];
     

--- a/hosts/common/configuration.nix
+++ b/hosts/common/configuration.nix
@@ -102,13 +102,15 @@
       configDir = "/home/beleap/Documents/.config/syncthing";
       overrideDevices = true;
       overrideFolders = true;
-      devices = deviceListExceptSelf;    
-      folders = {
-        "Logseq" = {
-          path = "/home/beleap/Documents/Logseq";
-          devices = deviceNameListExceptSelf;
+      settings = {
+        devices = deviceListExceptSelf;    
+        folders = {
+          "Logseq" = {
+            path = "/home/beleap/Documents/Logseq";
+            devices = deviceNameListExceptSelf;
+          };
         };
-    };
+      };
     };
   };
 

--- a/hosts/common/configuration.nix
+++ b/hosts/common/configuration.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, overlays, ... }:
+{ pkgs, lib, overlays, hostname, ... }:
 {
   imports = [
     <home-manager/nixos>
@@ -85,11 +85,30 @@
       };
     };
 
-    syncthing = {
+    syncthing = 
+    let
+      deviceList = {
+        "beleap-xps-9510" = { id = "ZKRXHYB-AD73BRK-E3QVAW7-EZ2ZYGY-RNGVUC3-BW6Y6GB-XNV2QM4-KIBOKAB"; };
+        "beleap-thinkpad" = { id = "ODOR4CS-P4X7FGR-6MRFBH4-DT4O2LE-Q22OTUF-2A2Z7CA-PXVYMZD-WPTZDAY"; };
+        "beleap-z-fold-4" = { id = "SY2FU6D-LRQURM2-EML4HUJ-KBPBPOH-3ENSLPL-2EKRZSU-7YSYCWH-VVBR6QX"; };
+      };
+      deviceListExceptSelf = (lib.attrsets.filterAttrs (n: v: n != hostname) deviceList);
+      deviceNameListExceptSelf = (lib.attrsets.foldlAttrs (acc: k: _: acc ++ [k]) [] deviceListExceptSelf);
+    in
+    {
       enable = true;
       user = "beleap";
       dataDir = "/home/beleap/Documents";
       configDir = "/home/beleap/Documents/.config/syncthing";
+      overrideDevices = true;
+      overrideFolders = true;
+      devices = deviceListExceptSelf;    
+      folders = {
+        "Logseq" = {
+          path = "/home/beleap/Documents/Logseq";
+          devices = deviceNameListExceptSelf;
+        };
+    };
     };
   };
 

--- a/users/beleap/files/.mozilla/native-messaging-hosts/firefoxpwa.json
+++ b/users/beleap/files/.mozilla/native-messaging-hosts/firefoxpwa.json
@@ -1,9 +1,0 @@
-{
-  "name": "firefoxpwa",
-  "description": "The native part of the PWAsForFirefox project",
-  "path": "/home/beleap/.nix-profile/libexec/firefoxpwa-connector",
-  "type": "stdio",
-  "allowed_extensions": [
-    "firefoxpwa@filips.si"
-  ]
-}

--- a/users/beleap/programs/autoload/firefox/default.nix
+++ b/users/beleap/programs/autoload/firefox/default.nix
@@ -2,7 +2,7 @@
 {
   enable = true;
 
-  package = pkgs.wrapFirefox pkgs.firefox-unwrapped {
+  package = pkgs.firefox.override {
     extraPolicies = {
       CaptivePortal = false;
       DisableFirefoxStudies = true;
@@ -25,9 +25,11 @@
         SkipOnboarding = true;
       };
     };
-    nativeMessagingHosts = with pkgs.nur.repos.rycee.firefox-addons; [
-      tridactyl
-    ];
+    nativeMessagingHosts = {
+      packages = with pkgs; [
+        tridactyl-native
+      ];
+    };
   };
 
   profiles = 

--- a/users/beleap/programs/autoload/firefox/default.nix
+++ b/users/beleap/programs/autoload/firefox/default.nix
@@ -25,11 +25,11 @@
         SkipOnboarding = true;
       };
     };
-    nativeMessagingHosts = {
-      packages = with pkgs; [
-        tridactyl-native
-      ];
-    };
+    # nativeMessagingHosts = {
+    #   packages = with pkgs; [
+    #     tridactyl-native
+    #   ];
+    # };
   };
 
   profiles = 

--- a/users/beleap/programs/autoload/firefox/default.nix
+++ b/users/beleap/programs/autoload/firefox/default.nix
@@ -25,10 +25,9 @@
         SkipOnboarding = true;
       };
     };
-    cfg = {
-      enableGnomeExtensions = true;
-      enableTridactylNative = true;
-    };
+    nativeMessagingHosts = with pkgs.nur.repos.rycee.firefox-addons; [
+      tridactyl
+    ];
   };
 
   profiles = 


### PR DESCRIPTION
- use nativeMessagingHosts instead of cfg
- setup syncthing
- chore: update lock
- fix: update deprecated options
- fix: remove unused file
- try: fix error
- fix: temporary disable tridactyl-native


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- Updated the function signature in the Nix configuration file for `beleap-thinkpad`, replacing the `config` parameter with `pkgs` and `specialArgs` for better modularity.
- Modified the Firefox configuration file, replacing `pkgs.wrapFirefox` with `pkgs.firefox.override` for improved customization.

New Features:
- Added a `hostname` parameter to the `common/configuration.nix` module, allowing for dynamic configuration based on the hostname.
- Enhanced the `syncthing` attribute in the `common/configuration.nix` module to include a device list, enabling better device management.

Style:
- Disabled certain Firefox features such as `CaptivePortal` and `DisableFirefoxStudies` for a cleaner user experience.

Please note that these changes are aimed at improving system configuration and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->