### PR TITLE
`yq` 최신 패키지로 변경

### DIFF
--- a/users/beleap/packages/default.nix
+++ b/users/beleap/packages/default.nix
@@ -11,7 +11,7 @@
     fzf
     gdb
     file
-    yq
+    yq-go
     jq
     lsd
     fd


### PR DESCRIPTION
기존 `yq` 패키지는 3.x 버전까지 지원하며 `yq-go` 패키지가 `4.x` 버전을 지원함